### PR TITLE
The synopsis for a switch statement in Perl programming language is as follows

### DIFF
--- a/array_switch.pl
+++ b/array_switch.pl
@@ -1,0 +1,14 @@
+#!/usr/local/bin/perl
+
+use Switch;
+
+@array = (10, 20, 30);
+
+switch($array) {
+   case 10           { print "number 100\n"; next; }
+   case "a"          { print "string a" }
+   case [1..10,42]   { print "number in list" }
+   case (\@array)    { print "number in list" }
+   case (\%hash)     { print "entry in hash" }
+   else              { print "previous case not true" }
+}

--- a/comment fle
+++ b/comment fle
@@ -1,0 +1,1 @@
+#this is a comment

--- a/fact.pl
+++ b/fact.pl
@@ -1,0 +1,9 @@
+$number = 5; # Change the number here 
+
+$fact = 1;
+
+for( $i = 1; $i <= $number ; $i=$i+1 ){
+    $fact = $fact*$i;
+}
+
+print "Factorial of $number is: $fact"

--- a/number_print
+++ b/number_print
@@ -1,0 +1,16 @@
+#!/usr/local/bin/perl
+
+use Switch;
+
+$var = 10;
+@array = (10, 20, 30);
+%hash = ('key1' => 10, 'key2' => 20);
+
+switch($var) {
+   case 10           { print "number 100\n" }
+   case "a"          { print "string a" }
+   case [1..10,42]   { print "number in list" }
+   case (\@array)    { print "number in list" }
+   case (\%hash)     { print "entry in hash" }
+   else              { print "previous case not true" }
+}

--- a/perl_switch_case.pl
+++ b/perl_switch_case.pl
@@ -1,0 +1,16 @@
+use Switch;
+ 
+# AND LATER...
+ 
+%special = ( woohoo => 1,  d'oh => 1 );
+ 
+while (<>) {
+    chomp;
+    switch ($_) {
+        case (%special) { print "homer\n"; }      # if $special{$_}
+        case /[a-z]/i   { print "alpha\n"; }      # if $_ =~ /a-z/i
+        case [1..9]     { print "small num\n"; }  # if $_ in [1..9]
+        case { $_[0] >= 10 } { print "big num\n"; } # if $_ >= 10
+        print "must be punctuation\n" case /\W/;  # if $_ ~= /\W/
+    }
+}

--- a/switch example
+++ b/switch example
@@ -1,0 +1,13 @@
+use Switch;
+
+switch(argument) {
+   case 1            { print "number 1" }
+   case "a"          { print "string a" }
+   case [1..10,42]   { print "number in list" }
+   case (\@array)    { print "number in list" }
+   case /\w+/        { print "pattern" }
+   case qr/\w+/      { print "pattern" }
+   case (\%hash)     { print "entry in hash" }
+   case (\&sub)      { print "arg to subroutine" }
+   else              { print "previous case not true" }
+}

--- a/switch.pl
+++ b/switch.pl
@@ -1,0 +1,14 @@
+use Switch;
+
+$var = 10;
+@array = (10, 20, 30);
+%hash = ('key1' => 10, 'key2' => 20);
+
+switch($var) {
+   case 10           { print "number 100\n" }
+   case "a"          { print "string a" }
+   case [1..10,42]   { print "number in list" }
+   case (\@array)    { print "number in list" }
+   case (\%hash)     { print "entry in hash" }
+   else              { print "previous case not true" }
+}

--- a/syntax of switch
+++ b/syntax of switch
@@ -1,0 +1,8 @@
+switch EXPR:
+    case EXPR:
+        SUITE
+    case EXPR:
+        SUITE
+    ...
+    else:
+        SUITE


### PR DESCRIPTION
`use Switch;

switch(argument) {
   case 1            { print "number 1" }
   case "a"          { print "string a" }
   case [1..10,42]   { print "number in list" }
   case (\@array)    { print "number in list" }
   case /\w+/        { print "pattern" }
   case qr/\w+/      { print "pattern" }
   case (\%hash)     { print "entry in hash" }
   case (\&sub)      { print "arg to subroutine" }
   else              { print "previous case not true" }
}`


### The following rules apply to a switch statement −

The switch statement takes a single scalar argument of any type, specified in parentheses.

The value is followed by a block, which may contain one or more case statement followed by a block of Perl statement(s).

A case statement takes a single scalar argument and selects the appropriate type of matching between the case argument and the current switch value.

If the match is successful, the mandatory block associated with the case statement is executed.

A switch statement can have an optional else case, which must appear at the end of the switch. The default case can be used for performing a task when none of the cases is matched.

If a case block executes an untargeted next, control is immediately transferred to the statement after the case statement (i.e., usually another case), rather than out of the surrounding switch block.

Not every case needs to contain a next. If no next appears, the flow of control will not fall through subsequent cases.

